### PR TITLE
Allow volume to be over 100%

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -91,7 +91,7 @@ export default class BalenaAudio extends PulseAudio {
 		this.checkConnected();
 		const sinkObject: Sink = await this.getSink(sink ?? this.defaultSink ?? 0);
 		const level: number = Math.round(
-			(Math.max(0, Math.min(volume, 100)) / 100) * sinkObject.baseVolume,
+			(Math.max(0, volume) / 100) * sinkObject.baseVolume,
 		);
 		return await this.setSinkVolume(sinkObject.index, level);
 	}


### PR DESCRIPTION
We want to have the maximum allowed volume for our devices at 120%. Unfortunately, balena-audio only allowed us to set the volume between 0% and 100%. As PulseAudio itself allows sinks to be at more than 100% volume, I think this library should also allow this.